### PR TITLE
The `ZinePageConfig` object

### DIFF
--- a/src/configs/CaptionConfig.ts
+++ b/src/configs/CaptionConfig.ts
@@ -1,0 +1,3 @@
+export default class CaptionConfig {
+
+}

--- a/src/configs/ZinePageConfig.test.ts
+++ b/src/configs/ZinePageConfig.test.ts
@@ -1,0 +1,25 @@
+import { Template } from "../templates";
+
+import ZinePageConfig from "./ZinePageConfig";
+import CaptionConfig from "./CaptionConfig";
+
+const imgRefArray = ["ref1", "ref2", "ref3"];
+const timeout = 2000;
+const captions = [new CaptionConfig()];
+const template = Template.SAMPLE;
+
+describe("ZinePageConfig", () => {
+  test("constructor", () => {
+    const testConfig = new ZinePageConfig({
+      images: imgRefArray,
+      viewTimeRequirement: timeout,
+      captions: captions,
+      templateId: template,
+    });
+
+    expect(testConfig.images).toEqual(imgRefArray);
+    expect(testConfig.viewTimeRequirement).toEqual(timeout);
+    expect(testConfig.captions).toEqual(captions);
+    expect(testConfig.templateId).toEqual(template);
+  });
+});

--- a/src/configs/ZinePageConfig.ts
+++ b/src/configs/ZinePageConfig.ts
@@ -1,0 +1,34 @@
+import { Template } from "../templates";
+
+import CaptionConfig from "./CaptionConfig";
+
+interface ZinePageInterface {
+  images: string[];
+  viewTimeRequirement: number;
+  captions: CaptionConfig[] | undefined;
+  templateId: Template | undefined;
+}
+/** Configuration class that's used to render individual pages. */
+export default class ZinePageConfig implements ZinePageInterface {
+  /** A collection of image references */
+  images: string[] = [];
+  /** The allotted amount of time to view a page */
+  viewTimeRequirement: number = 0;
+  /** A collection of caption configurations */
+  captions: CaptionConfig[] | undefined;
+  /** An enumerated ID for a template */
+  templateId: Template | undefined;
+  /** NOTE: **ONLY** use this for generating hard-coded
+   * @param params {ZinePageInterface} The configuration parameters */
+  constructor({
+    images,
+    viewTimeRequirement,
+    captions,
+    templateId,
+  }: ZinePageInterface) {
+    this.images = images;
+    this.viewTimeRequirement = viewTimeRequirement;
+    this.captions = captions;
+    this.templateId = templateId;
+  }
+}

--- a/src/templates/ZinePage.test.tsx
+++ b/src/templates/ZinePage.test.tsx
@@ -1,0 +1,20 @@
+import { render } from "@testing-library/react";
+
+import ZinePageConfig from "../configs/ZinePageConfig";
+
+import { ZinePage } from "./ZinePage";
+
+import { Template } from "./index";
+
+const testConfig = new ZinePageConfig({
+  images: [],
+  viewTimeRequirement: 0,
+  captions: undefined,
+  templateId: Template.SAMPLE,
+});
+
+describe("ZinePage", () => {
+  test("ZinePage renders", () => {
+    render(<ZinePage {...testConfig} />);
+  });
+});

--- a/src/templates/ZinePage.tsx
+++ b/src/templates/ZinePage.tsx
@@ -1,0 +1,5 @@
+import ZinePageConfig from "../configs/ZinePageConfig";
+
+export const ZinePage = (config: ZinePageConfig) => {
+  return <></>;
+};

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -1,0 +1,3 @@
+export enum Template {
+  SAMPLE = "sample",
+}


### PR DESCRIPTION
Fixes #2 

- Adds `ZinePageConfig` plus tests
- Adds `ZinePage` component that takes config members as props plus render test
- Adds empty `CaptionConfig` object for later