### PR TITLE
Template generation and prop validation

### DIFF
--- a/src/Zine.tsx
+++ b/src/Zine.tsx
@@ -1,21 +1,16 @@
 import React from "react";
 
 import image1 from "./images/img028.jpg";
-import image2 from "./images/img024.jpg";
-import image3 from "./images/img029-edit.jpg";
-import image4 from "./images/img002.jpg";
-import image5 from "./images/img020.jpg";
-import image6 from "./images/img012.jpg";
-import { Template } from "./templates";
+import { TemplateName } from "./templates";
 import { ZinePageConfig } from "./configs";
 import { ZinePage } from "./components";
 
 /* TODO: REMOVE!!! SAMPLE FOR DEVELOPING TEMPLATE!!! */
 const testPage = new ZinePageConfig({
-  images: [image1, image2, image3, image4, image5, image6],
-  viewTimeRequirement: 0,
+  images: [image1],
+  viewTimeRequirement: 1000,
   captions: undefined,
-  templateId: Template.SAMPLE,
+  templateId: TemplateName.MAINFRAME,
 });
 
 /** Controls the render flow of pages. */

--- a/src/components/ZinePage.test.tsx
+++ b/src/components/ZinePage.test.tsx
@@ -1,7 +1,7 @@
 import { render } from "@testing-library/react";
 
 import ZinePageConfig from "../configs/ZinePageConfig";
-import { Template } from "../templates";
+import { TemplateName } from "../templates";
 
 import { ZinePage } from "./ZinePage";
 
@@ -9,7 +9,7 @@ const testConfig = new ZinePageConfig({
   images: [],
   viewTimeRequirement: 0,
   captions: undefined,
-  templateId: Template.SAMPLE,
+  templateId: TemplateName.SAMPLE,
 });
 
 describe("ZinePage", () => {

--- a/src/components/ZinePage.tsx
+++ b/src/components/ZinePage.tsx
@@ -10,7 +10,7 @@ export const ZinePage = (config: ZinePageConfig) => {
     () =>
       new Template({
         props: config,
-        bundle: TEMPLATE_MAP.get(config.templateId)!!,
+        bundle: TEMPLATE_MAP.get(config.templateId)!!, // Throws inside Template if undefined
       }),
     [config]
   );

--- a/src/components/ZinePage.tsx
+++ b/src/components/ZinePage.tsx
@@ -1,13 +1,24 @@
+import { useEffect, useMemo } from "react";
+
 import ZinePageConfig from "../configs/ZinePageConfig";
-import { MainFrameTemplate } from "../templates/MainFrameTemplate";
+import { Template } from "../framework/Template";
+import { TEMPLATE_MAP } from "../templates";
 
 /** Controls the template generation and rendering of a page. */
 export const ZinePage = (config: ZinePageConfig) => {
-  const { images, viewTimeRequirement } = config;
-  return (
-    <MainFrameTemplate
-      images={images}
-      viewTimeRequirement={viewTimeRequirement}
-    />
+  const template = useMemo(
+    () =>
+      new Template({
+        props: config,
+        bundle: TEMPLATE_MAP.get(config.templateId)!!,
+      }),
+    [config]
   );
+
+  useEffect(() => {
+    template.validateProps();
+  }, [template]);
+
+  // TODO: Debug...not rendering!
+  return template.useTemplate();
 };

--- a/src/configs/ZinePageConfig.test.ts
+++ b/src/configs/ZinePageConfig.test.ts
@@ -1,4 +1,4 @@
-import { Template } from "../templates";
+import { TemplateName } from "../templates";
 
 import ZinePageConfig from "./ZinePageConfig";
 import CaptionConfig from "./CaptionConfig";
@@ -6,7 +6,7 @@ import CaptionConfig from "./CaptionConfig";
 const imgRefArray = ["ref1", "ref2", "ref3"];
 const timeout = 2000;
 const captions = [new CaptionConfig()];
-const template = Template.SAMPLE;
+const template = TemplateName.SAMPLE;
 
 describe("ZinePageConfig", () => {
   test("constructor", () => {

--- a/src/configs/ZinePageConfig.ts
+++ b/src/configs/ZinePageConfig.ts
@@ -1,4 +1,4 @@
-import { Template } from "../templates";
+import { TemplateName } from "../templates";
 
 import CaptionConfig from "./CaptionConfig";
 /** To extend the ZinePage capabilities, implement necessary params
@@ -7,17 +7,17 @@ interface ZinePageInterface {
   images: string[];
   viewTimeRequirement: number;
   captions: CaptionConfig[] | undefined;
-  templateId: Template | undefined;
+  templateId: TemplateName;
 }
 type BasicFeatures = "images" | "viewTimeRequirement";
 type BasicFeaturesWithCaptions = "images" | "viewTimeRequirement" | "captions";
 
 /** A basic template accepts an images array and viewTimeRequirement value.
  * NOTE: _How many_ images is determined by your template. */
-export type TemplateBasicInterface = Pick<ZinePageInterface, BasicFeatures>;
+export type BasicTemplateProps = Pick<ZinePageInterface, BasicFeatures>;
 /** A template that can take both images and captions.
  * NOTE: _How many_ images and captions are determined by your template. */
-export type TemplateWithCaptionsInterface = Pick<
+export type TemplateWithCaptionsProps = Pick<
   ZinePageInterface,
   BasicFeaturesWithCaptions
 >;
@@ -31,7 +31,7 @@ export default class ZinePageConfig implements ZinePageInterface {
   /** A collection of caption configurations */
   captions: CaptionConfig[] | undefined;
   /** An enumerated ID for a template */
-  templateId: Template | undefined;
+  templateId: TemplateName;
   /** NOTE: **ONLY** use this for generating hard-coded
    * @param params {ZinePageInterface} The configuration parameters */
   constructor({

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -1,7 +1,7 @@
 import ZinePageConfig, {
-  TemplateBasicInterface,
-  TemplateWithCaptionsInterface,
+  BasicTemplateProps,
+  TemplateWithCaptionsProps,
 } from "./ZinePageConfig";
 
 export { ZinePageConfig };
-export type { TemplateBasicInterface, TemplateWithCaptionsInterface };
+export type { BasicTemplateProps, TemplateWithCaptionsProps };

--- a/src/errors/InvalidPropsError.ts
+++ b/src/errors/InvalidPropsError.ts
@@ -1,0 +1,6 @@
+export default class InvalidPropsError extends Error {
+  constructor(message: string) {
+    super(message);
+    Object.setPrototypeOf(this, InvalidPropsError.prototype);
+  }
+}

--- a/src/errors/UndefinedBundleError.ts
+++ b/src/errors/UndefinedBundleError.ts
@@ -1,0 +1,6 @@
+export default class UndefinedBundleError extends Error {
+  constructor(message: string) {
+    super(`Could not find bundle from templateId: ${message}`);
+    Object.setPrototypeOf(this, UndefinedBundleError.prototype);
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,3 +1,4 @@
 import InvalidTemplatePropsError from "./InvalidPropsError";
+import UndefinedBundleError from "./UndefinedBundleError";
 
-export { InvalidTemplatePropsError };
+export { InvalidTemplatePropsError, UndefinedBundleError };

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,3 @@
+import InvalidTemplatePropsError from "./InvalidPropsError";
+
+export { InvalidTemplatePropsError };

--- a/src/framework/Template.ts
+++ b/src/framework/Template.ts
@@ -1,0 +1,55 @@
+/* IDEAS:
+ *
+ * Package template components as JSX-returning functions along with
+ * a prop validator
+ *
+ * . */
+
+import { TemplateName } from "../templates";
+import { ZinePageConfig } from "../configs";
+/** Validator will either return a boolean or throw with no return */
+type ValidatorReturn = boolean | never;
+/** Function that validates props for a template */
+export type ValidatorFunction = (props: ZinePageConfig) => ValidatorReturn;
+/** Function that generates a hydrated template */
+export type TemplateGenerator<T> = (props: T) => JSX.Element;
+/** The core members of a TemplateBundle */
+export interface TemplateBundleInterface<T = any> {
+  id: TemplateName;
+  generator: TemplateGenerator<T>;
+  validator: ValidatorFunction;
+}
+/** Object containing methods and members to validate and return a hydrated
+ * template. */
+export class TemplateBundle implements TemplateBundleInterface {
+  id;
+  generator;
+  validator;
+  constructor({ id, generator, validator }: TemplateBundleInterface) {
+    this.id = id;
+    this.generator = generator;
+    this.validator = validator;
+  }
+}
+
+interface TemplateInterface {
+  props: ZinePageConfig;
+  bundle: TemplateBundle;
+}
+export class Template implements TemplateInterface {
+  props;
+  bundle;
+  constructor({ props, bundle }: TemplateInterface) {
+    this.props = props;
+    this.bundle = bundle;
+  }
+  /** Will use `TemplateBundle.validator` to validate props.
+   * @throws {InvalidPropsError} */
+  validateProps(): boolean {
+    return this.bundle.validator(this.props);
+  }
+  /** Uses `TemplateBungle.generator` and hydrates it with props. */
+  useTemplate(): JSX.Element {
+    return this.bundle.generator(this.props);
+  }
+}

--- a/src/framework/Template.ts
+++ b/src/framework/Template.ts
@@ -7,6 +7,7 @@
 
 import { TemplateName } from "../templates";
 import { ZinePageConfig } from "../configs";
+import { UndefinedBundleError } from "../errors";
 /** Validator will either return a boolean or throw with no return */
 type ValidatorReturn = boolean | never;
 /** Function that validates props for a template */
@@ -40,6 +41,7 @@ export class Template implements TemplateInterface {
   props;
   bundle;
   constructor({ props, bundle }: TemplateInterface) {
+    if (bundle === undefined) throw new UndefinedBundleError(props.templateId);
     this.props = props;
     this.bundle = bundle;
   }

--- a/src/templates/MainFrameTemplate.test.tsx
+++ b/src/templates/MainFrameTemplate.test.tsx
@@ -1,10 +1,10 @@
 import { render } from "@testing-library/react";
 
-import { TemplateBasicInterface } from "../configs/ZinePageConfig";
+import { BasicTemplateProps } from "../configs/ZinePageConfig";
 
 import { MainFrameTemplate } from "./MainFrameTemplate";
 
-const testConfig: TemplateBasicInterface = {
+const testConfig: BasicTemplateProps = {
   images: ["sample-src/sample-img.jpg"],
   viewTimeRequirement: 0,
 };

--- a/src/templates/MainFrameTemplate.tsx
+++ b/src/templates/MainFrameTemplate.tsx
@@ -1,8 +1,12 @@
-import { TemplateBasicInterface } from "../configs";
+import React from "react";
+
+import { BasicTemplateProps, ZinePageConfig } from "../configs";
 import { Container, Frame, Image } from "../components";
+import { ValidatorFunction } from "../framework/Template";
+import { InvalidTemplatePropsError } from "../errors";
 
 /** TEMPLATE: A single image in a frame. */
-export const MainFrameTemplate = (config: TemplateBasicInterface) => {
+export const MainFrameTemplate: React.FC<BasicTemplateProps> = (config) => {
   return (
     <Container>
       <Frame width={87} height={87}>
@@ -11,3 +15,30 @@ export const MainFrameTemplate = (config: TemplateBasicInterface) => {
     </Container>
   );
 };
+
+export const imageError = (length: number) =>
+  `This template only supports one image, received: ${length}`;
+export const imageCheck = (images: string[]) => {
+  if (images.length > 1)
+    throw new InvalidTemplatePropsError(imageError(images.length));
+  return true;
+};
+
+export const timeError = (time: number) =>
+  `The viewTimeRequirement must exceed 1 second (1000). Received: ${time}`;
+export const viewTimeCheck = (time: number) => {
+  if (time < 1000) throw new InvalidTemplatePropsError(timeError(time));
+  return true;
+};
+
+export const mainFramePropValidator: ValidatorFunction = (props) => {
+  const { images, viewTimeRequirement } = props;
+  return imageCheck(images) && viewTimeCheck(viewTimeRequirement);
+};
+
+export const mainFrameGenerator = (props: ZinePageConfig) => (
+  <MainFrameTemplate
+    images={props.images}
+    viewTimeRequirement={props.viewTimeRequirement}
+  />
+);

--- a/src/templates/MainFrameTemplate.tsx
+++ b/src/templates/MainFrameTemplate.tsx
@@ -10,7 +10,7 @@ export const MainFrameTemplate: React.FC<BasicTemplateProps> = (config) => {
   return (
     <Container>
       <Frame width={87} height={87}>
-        <Image src={config.images[1]} />
+        <Image src={config.images[0]} />
       </Frame>
     </Container>
   );

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -1,8 +1,25 @@
-import { MainFrameTemplate } from "./MainFrameTemplate";
+import { TemplateBundle } from "../framework/Template";
 
-export enum Template {
+import {
+  mainFrameGenerator,
+  mainFramePropValidator,
+  MainFrameTemplate,
+} from "./MainFrameTemplate";
+
+export enum TemplateName {
   SAMPLE = "sample",
   MAINFRAME = "main-frame",
 }
+
+export const mainFrameBundle = new TemplateBundle({
+  id: TemplateName.MAINFRAME,
+  generator: mainFrameGenerator,
+  validator: mainFramePropValidator,
+});
+
+export const TEMPLATE_MAP = new Map<TemplateName, TemplateBundle>().set(
+  TemplateName.MAINFRAME,
+  mainFrameBundle
+);
 
 export { MainFrameTemplate };


### PR DESCRIPTION
Fixes #5 

Adds the following:
- Template feature types
- `TemplateBundle` and `Template` classes for validation and use of templates
- Prop validation and template creation function types
- Hooks template use into `ZinePage`
- Additional cleanup and refactor