### PR TITLE
Component generator added to CLI

### DIFF
--- a/cli/generators/code-templates/block.ts
+++ b/cli/generators/code-templates/block.ts
@@ -1,0 +1,4 @@
+import styled from "styled-components";
+
+/** Include JSDOC for COMPONENT_NAME */
+export const COMPONENT_NAME = styled.div``;

--- a/cli/generators/code-templates/logic.tsx
+++ b/cli/generators/code-templates/logic.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+interface COMPONENT_NAMEProps {}
+/** Include JSDOC for COMPONENT_NAME */
+export const COMPONENT_NAME: React.FC<COMPONENT_NAMEProps> = ({}) => {
+  return <></>;
+};

--- a/cli/generators/make-component.sh
+++ b/cli/generators/make-component.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+IMPORT="import { COMPONENT_NAME } from \"./COMPONENT_TYPE/COMPONENT_NAME\";"
+EXPORT="export { COMPONENT_NAME };"
+FILE_EXTENSION=""
+
+read -p "Type (logic or block): " componentType
+read -p "Name: " componentName
+
+if [[ -z $componentType ]] || [[ -z $componentName ]]
+then
+  echo "ERROR, requires inputs: [type] [Name]"
+  exit 1
+elif [[ $componentType != "logic" ]] && [[ $componentType != "block" ]]
+then
+  echo "ERROR, valid [type] args: logic, block"
+  exit 1
+fi
+
+if [[ $componentType != "logic" ]]
+then
+  FILE_EXTENSION="ts"
+else
+  FILE_EXTENSION="tsx"
+fi
+
+touch ../../src/components/$componentType/$componentName.$FILE_EXTENSION
+sed -e "s/COMPONENT_NAME/$componentName/g" ./code-templates/$componentType.$FILE_EXTENSION > ../../src/components/$componentType/$componentName.$FILE_EXTENSION
+
+echo $IMPORT|cat - ../../src/components/index.ts > /tmp/out && mv /tmp/out ../../src/components/index.ts
+echo $EXPORT >> ../../src/components/index.ts
+sed -i.old "s/COMPONENT_NAME/$componentName/g" ../../src/components/index.ts
+sed -i.old "s/COMPONENT_TYPE/$componentType/g" ../../src/components/index.ts
+rm ../../src/components/index.ts.old

--- a/src/components/block/Container.ts
+++ b/src/components/block/Container.ts
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+`;

--- a/src/components/block/Frame.ts
+++ b/src/components/block/Frame.ts
@@ -1,10 +1,4 @@
 import styled from "styled-components";
-
-export const Container = styled.div`
-  width: 100vw;
-  height: 100vh;
-  display: flex;
-`;
 /** Width and height, in vw/vh percentage, for image frame.
  * The higher the percentage, the less border around the image. */
 interface FrameProps {
@@ -15,12 +9,4 @@ export const Frame = styled.div<FrameProps>`
   width: ${(props) => `${props?.width}%`};
   height: ${(props) => `${props?.height}%`};
   margin: auto;
-`;
-
-export const Image = styled.img`
-  display: block;
-  height: 100%;
-  width: auto;
-  margin: 0px auto;
-  object-fit: contain;
 `;

--- a/src/components/block/Image.ts
+++ b/src/components/block/Image.ts
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+export const Image = styled.img`
+  display: block;
+  height: 100%;
+  width: auto;
+  margin: 0px auto;
+  object-fit: contain;
+`;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,16 +1,18 @@
-import { Frame, Image, Container } from "./blocks/ImageFrame";
+import {} from ".//";
+import {} from ".//";
+import {} from ".//";
+import { Frame } from "./block/Frame";
+import { Container } from "./block/Container";
+import { Image } from "./block/Image";
 import PageProvider, { usePageContext } from "./logic/PageProvider";
 import TemplateErrorBoundary from "./logic/TemplateErrorBoundary";
 import { Zine } from "./logic/Zine";
 import { ZinePage } from "./logic/ZinePage";
 
-export {
-  Frame,
-  Image,
-  Container,
-  PageProvider,
-  usePageContext,
-  TemplateErrorBoundary,
-  ZinePage,
-  Zine,
-};
+export { Frame };
+export { Container };
+export { Image };
+export { PageProvider, usePageContext };
+export { TemplateErrorBoundary };
+export { Zine };
+export { ZinePage };

--- a/zine.sh
+++ b/zine.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [[ $1 == "-C" ]]
+if [[ $1 == "component" ]]
 then
   /bin/bash ./cli/generators/make-component.sh
 fi

--- a/zine.sh
+++ b/zine.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if [[ $1 == "-C" ]]
+then
+  /bin/bash ./cli/generators/make-component.sh
+fi


### PR DESCRIPTION
Fixes #20 

Adds in the ability to
- Make components with `./zine.sh component`

Behind the scenes:
- Adds to `components/index`
- Dynamically controls ts and tsx extension for JSX-inclusive files (logic only)